### PR TITLE
Bump PyCC Version To Fix Nested Directories Bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pypif==2.0.1
 pypif_sdk>=2.2.1,<3
-citrination_client>=4.4.1,<5
+citrination_client>=4.4.2,<5
 stevedore
 matmeta==0.1.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='pif_ingestor',
       install_requires=[
           "pypif>=2.0.0,<3",
           "pypif_sdk>=2.2.1,<3",
-          "citrination_client>=4.4.1,<5",
+          "citrination_client>=4.4.2,<5",
           "stevedore"
       ],
       extras_require={


### PR DESCRIPTION
Bumping to PyCC version 4.4.2 solves a bug where if you used the
  recursive option, you would see double nesting of certain directories
  on the Citrination platform.

  From the tests/ directory in this repo run this command to see the fix in
  action.

  pif-ingestor -r -f dft dft -d {dataset id}

  There should be no doubly nested directories on Citrination in the dataset you specify